### PR TITLE
Add dual authenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # ignore these
+.idea/
+*.iml
 apacheds_awsiam.jar
 ivylib/
 ivyout/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ apacheds_awsiam.jar
 ivylib/
 ivyout/
 target/
+out/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# ignore these
+apacheds_awsiam.jar
+ivylib/
+ivyout/
+target/
+

--- a/build.xml
+++ b/build.xml
@@ -29,7 +29,7 @@
              uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
     <ivy:settings file="${basedir}/ivysettings.xml" />
     <ivy:retrieve  />
-    <target name="compile">
+    <target name="compile" depends="clean">
          <delete dir="${outdir}" failonerror="false" />
          <mkdir dir="${outdir}" />
          <javac srcdir="${basedir}/src" destdir="${basedir}/ivyout" debug="true" debuglevel="lines,vars,source">
@@ -71,6 +71,12 @@
 
         <delete file="${basedir}/target/apacheds.zip" failonerror="false" />
         <zip file="${basedir}/target/apacheds.zip" basedir="${basedir}/target"/>
+        <unzip src="${targetdir}/instances/default.zip" dest="${targetdir}/instances/"/>
+    </target>
+
+    <target name="clean">
+        <delete dir="${outdir}" failonerror="false"/>
+        <delete dir="${targetdir}" failonerror="false"/>
     </target>
 
 </project>

--- a/dist/apacheds/bin/apacheds.sh
+++ b/dist/apacheds/bin/apacheds.sh
@@ -17,6 +17,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
+set -x
 
 # Detect ads home (http://stackoverflow.com/a/630387/516433)
 ADS_HOME="`dirname \"$0\"`"
@@ -85,8 +86,8 @@ ADS_CONTROLS="-Dapacheds.controls=org.apache.directory.api.ldap.codec.controls.c
 
 ADS_EXTENDED_OPERATIONS="-Dapacheds.extendedOperations=org.apache.directory.api.ldap.extras.extended.ads_impl.cancel.CancelFactory,org.apache.directory.api.ldap.extras.extended.ads_impl.certGeneration.CertGenerationFactory,org.apache.directory.api.ldap.extras.extended.ads_impl.gracefulShutdown.GracefulShutdownFactory,org.apache.directory.api.ldap.extras.extended.ads_impl.storedProcedure.StoredProcedureFactory,org.apache.directory.api.ldap.extras.extended.ads_impl.gracefulDisconnect.GracefulDisconnectFactory"
 
-if [ "$ADS_ACTION" = "start" ]; then
-    # Printing instance informatio
+if [ "$ADS_ACTION" = "start" ] || [ "$ADS_ACTION" = "console" ]; then
+    # Printing instance information
     echo "Starting ApacheDS instance '$ADS_INSTANCE_NAME'..."
 
     if [ -f "$ADS_PID" ]; then
@@ -97,6 +98,11 @@ if [ "$ADS_ACTION" = "start" ]; then
             exit 1;
         fi
     fi
+    if [ "$ADS_ACTION" = "start" ]; then
+        DAEMONIZE="> '$ADS_OUT' 2>&1 &"
+    else
+        DAEMONIZE=""
+    fi
 
     # Launching ApacheDS
     eval "\"$RUN_JAVA\"" $JAVA_OPTS $ADS_CONTROLS $ADS_EXTENDED_OPERATIONS \
@@ -104,7 +110,7 @@ if [ "$ADS_ACTION" = "start" ]; then
         -Dapacheds.log.dir="\"$ADS_HOME/instances/$ADS_INSTANCE_NAME/log\"" \
         -classpath "\"$CLASSPATH\"" \
         org.apache.directory.server.UberjarMain "\"$ADS_HOME/instances/$ADS_INSTANCE_NAME\"" \
-        > "$ADS_OUT" 2>&1 "&"
+        "$DAEMONIZE"
     echo $! > "$ADS_PID"
 elif [ "$ADS_ACTION" = "stop" ]; then
     # Printing instance information

--- a/src/com/denismo/aws/iam/IAMDualValidator.java
+++ b/src/com/denismo/aws/iam/IAMDualValidator.java
@@ -1,0 +1,35 @@
+package com.denismo.aws.iam;
+
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidAttributeValueException;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by jweede on 4/5/16.
+ */
+public class IAMDualValidator implements _IAMPasswordValidator {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(IAMDualValidator.class);
+
+    private List<_IAMPasswordValidator> validators;
+
+    public IAMDualValidator() {
+        this.validators = new LinkedList<>();
+        this.validators.add(new IAMAccountPasswordValidator());
+        this.validators.add(new IAMSecretKeyValidator());
+    }
+
+    @Override
+    public boolean verifyIAMPassword(Entry user, String pw) throws LdapInvalidAttributeValueException, LdapAuthenticationException {
+        for (_IAMPasswordValidator v : this.validators) {
+            LOG.debug("Dual Validator: trying {} for {}", v.getClass().getName(), user.get("uid").toString());
+            if (v.verifyIAMPassword(user, pw)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/com/denismo/aws/iam/LDAPIAMPoller.java
+++ b/src/com/denismo/aws/iam/LDAPIAMPoller.java
@@ -19,10 +19,7 @@
 package com.denismo.aws.iam;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
 import com.amazonaws.services.identitymanagement.model.*;
@@ -32,7 +29,7 @@ import com.denismo.apacheds.auth.AWSIAMAuthenticator;
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;
 import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.entry.*;
-import org.apache.directory.api.ldap.model.exception.LdapInvalidAttributeValueException;
+import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapNoSuchObjectException;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
 import org.apache.directory.api.ldap.model.filter.FilterParser;
@@ -41,31 +38,21 @@ import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.name.Rdn;
 import org.apache.directory.api.ldap.model.schema.normalizers.ConcreteNameComponentNormalizer;
 import org.apache.directory.api.ldap.model.schema.normalizers.NameComponentNormalizer;
-import org.apache.directory.server.constants.ApacheSchemaConstants;
 import org.apache.directory.server.core.api.DirectoryService;
-import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.server.core.api.DnFactory;
 import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
-import org.apache.directory.server.core.api.interceptor.context.*;
+import org.apache.directory.server.core.api.interceptor.context.HasEntryOperationContext;
+import org.apache.directory.server.core.api.interceptor.context.LookupOperationContext;
+import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
 import org.apache.directory.server.core.api.normalization.FilterNormalizingVisitor;
-import org.apache.directory.server.core.api.partition.Partition;
-import org.apache.directory.server.core.partition.impl.btree.AbstractBTreePartition;
-import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmIndex;
-import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
-import org.apache.directory.server.xdbm.Index;
-import org.apache.directory.server.xdbm.ParentIdAndRdn;
-import org.apache.directory.server.xdbm.Store;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -553,7 +540,7 @@ public class LDAPIAMPoller {
         }
 
         DefaultEntry ent = new DefaultEntry(directory.getSchemaManager(), directory.getDnFactory().create(String.format(USER_FMT, user.getUserName())));
-        ent.put(SchemaConstants.OBJECT_CLASS_AT, "posixAccount", "shadowAccount", "iamaccount");
+        ent.put(SchemaConstants.OBJECT_CLASS_AT, "posixAccount", "shadowAccount", "iamaccount", "extensibleObject");
         ent.put("accessKey", accessKey);
         ent.put("uid", user.getUserName());
         ent.put(SchemaConstants.ENTRY_CSN_AT, directory.getCSN().toString());


### PR DESCRIPTION
Added a simple authenticator that tries both IAM validators (password and secret key) and validates if at least one of them returns true.

I added a few other things:

 - a `.gitignore` file. Didn't want to commit artifacts by mistake
 - a 'clean' step to the ant script. Made testing much easier.
 - Gave users 'objectClass: extensibleObject'. Much easier to add custom attributes.
 - added a 'console' option to the shell script. Makes it much easier to hook up apacheds to supervisor and other similar init systems.

Thanks! Let me know what you think.